### PR TITLE
Add responsive Next.js portfolio frontend site

### DIFF
--- a/portfolio/.eslintrc.json
+++ b/portfolio/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/portfolio/.gitignore
+++ b/portfolio/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+.env*
+
+# generated
+src/styles/generated/

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -1,0 +1,20 @@
+# Jian Choi Portfolio (Next.js)
+
+스마트폰, 태블릿, 데스크탑 환경을 모두 고려한 반응형 프론트엔드 포트폴리오 사이트입니다. Next.js (App Router)와 TypeScript, Tailwind CSS, module.scss를 조합하여 구성했습니다.
+
+## 주요 특징
+
+- **반응형 레이아웃**: 3단계 브레이크포인트 기반으로 Hero, 프로젝트, 역량, 경력 섹션이 레이아웃을 전환합니다.
+- **데이터 드리븐 컴포넌트**: 프로젝트 정보는 `src/data/projects.ts`에서 정의되어 카드 컴포넌트로 매핑됩니다.
+- **Tailwind + module.scss**: 글로벌 스타일과 유틸리티는 Tailwind로, 섬세한 효과는 SCSS 모듈로 관리합니다.
+- **Framer Motion 인터랙션**: 상단 네비게이션의 진행 바와 Hero 섹션에 부드러운 애니메이션을 적용했습니다.
+
+## 사용 방법
+
+```bash
+cd portfolio
+npm install
+npm run dev
+```
+
+포트폴리오는 `http://localhost:3000`에서 확인할 수 있습니다.

--- a/portfolio/next-env.d.ts
+++ b/portfolio/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/portfolio/next.config.mjs
+++ b/portfolio/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "portfolio",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@heroicons/react": "^2.1.5",
+    "@tailwindcss/typography": "^0.5.10",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.2.10",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.18",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/portfolio/postcss.config.js
+++ b/portfolio/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/portfolio/public/favicon.svg
+++ b/portfolio/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7f5af0" />
+      <stop offset="100%" stop-color="#1f7aff" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="18" fill="url(#grad)" />
+  <path d="M20 44L24 20H30L34 34L38 20H44L48 44H42.5L39.5 27.5L35 44H29.5L25 27.5L22 44H20Z" fill="#fff" />
+</svg>

--- a/portfolio/public/images/hero/profile-bubble.svg
+++ b/portfolio/public/images/hero/profile-bubble.svg
@@ -1,0 +1,10 @@
+<svg width="320" height="320" viewBox="0 0 320 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bubble" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 160) rotate(90) scale(160)">
+      <stop offset="0" stop-color="#A5CAFF" stop-opacity="0.75" />
+      <stop offset="0.55" stop-color="#7F5AF0" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#1F7AFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <circle cx="160" cy="160" r="160" fill="url(#bubble)" />
+</svg>

--- a/portfolio/public/images/projects/energy-rapp/monitor.svg
+++ b/portfolio/public/images/projects/energy-rapp/monitor.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#0f766e' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#22d3ee' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Energy Monitor
+  </text>
+</svg>

--- a/portfolio/public/images/projects/energy-rapp/overview.svg
+++ b/portfolio/public/images/projects/energy-rapp/overview.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#1d4ed8' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#9333ea' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Site Overview
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-1/dashboard.svg
+++ b/portfolio/public/images/projects/oran-dashboard-1/dashboard.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#1f7aff' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#38bdf8' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    O-RAN RICS 1.0 Overview
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-1/near-rt.svg
+++ b/portfolio/public/images/projects/oran-dashboard-1/near-rt.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2563eb' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#7f5af0' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Near-RT RIC
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-1/non-rt.svg
+++ b/portfolio/public/images/projects/oran-dashboard-1/non-rt.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#0ea5e9' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#7f5af0' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Non-RT RIC
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-2/dashboard.svg
+++ b/portfolio/public/images/projects/oran-dashboard-2/dashboard.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#4b94ff' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#7f5af0' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    O-RAN RICS 2.0 Dashboard
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-2/diagnostic.svg
+++ b/portfolio/public/images/projects/oran-dashboard-2/diagnostic.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#1f7aff' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#06b6d4' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Diagnostic Monitor
+  </text>
+</svg>

--- a/portfolio/public/images/projects/oran-dashboard-2/performance.svg
+++ b/portfolio/public/images/projects/oran-dashboard-2/performance.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#312e81' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#7f5af0' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Performance Metrics
+  </text>
+</svg>

--- a/portfolio/public/images/projects/ulsan-memorial/facility.svg
+++ b/portfolio/public/images/projects/ulsan-memorial/facility.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2563eb' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#f59e0b' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Facility Overview
+  </text>
+</svg>

--- a/portfolio/public/images/projects/ulsan-memorial/intro.svg
+++ b/portfolio/public/images/projects/ulsan-memorial/intro.svg
@@ -1,0 +1,13 @@
+
+<svg width='640' height='360' viewBox='0 0 640 360' xmlns='http://www.w3.org/2000/svg'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#7c3aed' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='#f472b6' stop-opacity='0.95'/>
+    </linearGradient>
+  </defs>
+  <rect width='640' height='360' rx='32' fill='url(#grad)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='rgba(255,255,255,0.92)' font-family='"Pretendard", "Segoe UI", sans-serif' font-size='32' font-weight='600'>
+    Memorial Home Intro
+  </text>
+</svg>

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -1,0 +1,27 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable.css');
+@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  background-color: #f3f6fc;
+}
+
+body {
+  font-family: "Pretendard Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: linear-gradient(180deg, #f9fbff 0%, #eef3ff 100%);
+  color: #0f172a;
+  min-height: 100vh;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #78afff 0%, #1f7aff 100%);
+  border-radius: 9999px;
+}

--- a/portfolio/src/app/icon.svg
+++ b/portfolio/src/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7f5af0" />
+      <stop offset="100%" stop-color="#1f7aff" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="18" fill="url(#grad)" />
+  <path d="M20 44L24 20H30L34 34L38 20H44L48 44H42.5L39.5 27.5L35 44H29.5L25 27.5L22 44H20Z" fill="#fff" />
+</svg>

--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { clsx } from "clsx";
+import type { ReactNode } from "react";
+import { Footer } from "@/components/Footer";
+import { Navigation } from "@/components/Navigation";
+
+export const metadata: Metadata = {
+  title: "Jian Choi · Frontend Engineer",
+  description: "스마트한 통신/에너지 대시보드를 설계한 프론트엔드 개발자 최지안의 포트폴리오",
+  keywords: [
+    "Next.js",
+    "TypeScript",
+    "Tailwind CSS",
+    "Frontend Developer",
+    "Portfolio"
+  ]
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="ko">
+      <body
+        className={clsx(
+          "min-h-screen bg-gradient-to-br from-primary-50 via-white to-primary-100 text-slate-900",
+          "antialiased"
+        )}
+      >
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-4 pb-12 pt-8 sm:px-8 lg:px-12">
+          <Navigation />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,0 +1,17 @@
+import { CareerSection } from "@/components/CareerSection";
+import { Hero } from "@/components/Hero";
+import { ProjectSection } from "@/components/ProjectSection";
+import { SkillSection } from "@/components/SkillSection";
+import { SummarySection } from "@/components/SummarySection";
+
+export default function HomePage() {
+  return (
+    <div className="space-y-16 pb-16">
+      <Hero />
+      <SummarySection />
+      <ProjectSection />
+      <SkillSection />
+      <CareerSection />
+    </div>
+  );
+}

--- a/portfolio/src/components/CareerSection.tsx
+++ b/portfolio/src/components/CareerSection.tsx
@@ -1,0 +1,57 @@
+import { SectionHeader } from "./SectionHeader";
+
+const experiences = [
+  {
+    title: "ETRI 지능형 스웜랩 연구실",
+    role: "연구원 (프론트엔드)",
+    period: "2024.01 - 현재",
+    details: [
+      "O-RAN RICS 관제 대시보드 1.0/2.0 프론트엔드 총괄",
+      "실시간 데이터 Mocking 환경 및 배포 자동화 설계",
+      "연구 결과 발표 및 국제 학회 데모 세션 참여"
+    ]
+  },
+  {
+    title: "울산 하늘공원 장례식장",
+    role: "프리랜서 프론트엔드",
+    period: "2024.07 - 2025.01",
+    details: [
+      "시설 안내/예약 반응형 웹 구축",
+      "운영팀 요구사항 기반 CMS 구조 제안",
+      "상담 전환율 분석을 위한 데이터 수집 플로우 설계"
+    ]
+  }
+];
+
+export function CareerSection() {
+  return (
+    <section id="career" className="space-y-8">
+      <SectionHeader
+        eyebrow="경험"
+        title="협업과 성장을 이끈 여정"
+        description="연구 기관과 민간 프로젝트에서 사용자 중심의 제품 개선을 이끈 경험을 통해 다양한 도메인의 이해관계를 조율해왔습니다."
+      />
+      <div className="space-y-6">
+        {experiences.map((experience) => (
+          <div key={experience.title} className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-lg shadow-primary-100/30">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="font-display text-xl font-semibold text-slate-900">{experience.title}</h3>
+                <p className="text-sm text-primary-600">{experience.role}</p>
+              </div>
+              <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">{experience.period}</span>
+            </div>
+            <ul className="mt-4 space-y-2 text-sm text-slate-600">
+              {experience.details.map((detail) => (
+                <li key={detail} className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-primary-400" />
+                  <span>{detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/portfolio/src/components/Footer.tsx
+++ b/portfolio/src/components/Footer.tsx
@@ -1,0 +1,25 @@
+import { EnvelopeIcon, PhoneIcon } from "@heroicons/react/24/outline";
+
+export function Footer() {
+  return (
+    <footer id="contact" className="rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-lg shadow-primary-100/30">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="font-display text-xl font-semibold text-primary-700">사용자의 소소한 순간까지 고민하는 프론트엔드 개발자</p>
+          <p className="mt-2 max-w-xl text-sm text-slate-600">
+            실사용자 기반 데이터 대시보드와 반응형 서비스에 강점을 가지며, 문제 탐색부터 인터랙션 구현까지 전 과정을 주도적으로 이끈 경험이 있습니다.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 text-sm text-slate-600">
+          <a href="mailto:moc24@naver.com" className="flex items-center gap-2 hover:text-primary-600">
+            <EnvelopeIcon className="h-5 w-5" /> moc24@naver.com
+          </a>
+          <a href="tel:01040963487" className="flex items-center gap-2 hover:text-primary-600">
+            <PhoneIcon className="h-5 w-5" /> 010-4096-3487
+          </a>
+        </div>
+      </div>
+      <p className="mt-8 text-xs text-slate-400">© {new Date().getFullYear()} Jian Choi. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/portfolio/src/components/Hero.tsx
+++ b/portfolio/src/components/Hero.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+import { ArrowDownIcon } from "@heroicons/react/24/outline";
+import { motion } from "framer-motion";
+
+export function Hero() {
+  return (
+    <section id="top" className="grid gap-10 rounded-3xl border border-slate-200/60 bg-white/80 p-8 shadow-xl shadow-primary-100/50 md:grid-cols-[1.1fr_0.9fr] md:items-center">
+      <div className="space-y-6">
+        <span className="inline-flex items-center gap-2 rounded-full border border-primary-200/70 bg-primary-50 px-4 py-1 text-xs font-semibold text-primary-700">
+          #사용자 경험 #편리함 #소통 중심
+        </span>
+        <h1 className="font-display text-3xl font-bold leading-tight text-slate-900 sm:text-4xl lg:text-5xl">
+          사용자의 실시간 의사결정을 돕는 데이터 대시보드를 설계하는 프론트엔드 개발자 최지안입니다.
+        </h1>
+        <p className="max-w-xl text-base text-slate-600">
+          통신/에너지 영역의 복잡한 데이터를 이해하기 쉬운 사용자 경험으로 바꾸고, 현장의 피드백을 인터랙션으로 검증하며 제품의 지속적인 개선을 이끌어왔습니다.
+        </p>
+        <div className="flex flex-wrap gap-3 text-sm">
+          {[
+            "Next.js & TypeScript 기반 설계",
+            "실시간 데이터 시각화",
+            "협업을 위한 디자인 시스템"
+          ].map((item) => (
+            <span key={item} className="rounded-full border border-primary-200 bg-white px-4 py-2 text-primary-600">
+              {item}
+            </span>
+          ))}
+        </div>
+        <a
+          href="#projects"
+          className="inline-flex items-center gap-2 rounded-full bg-primary-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-primary-200/60 transition hover:bg-primary-500"
+        >
+          프로젝트 살펴보기 <ArrowDownIcon className="h-4 w-4" />
+        </a>
+      </div>
+      <motion.div
+        className="relative"
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.6 }}
+      >
+        <div className="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-gradient-to-br from-primary-500/10 via-accent/10 to-primary-700/10 p-6">
+          <div className="space-y-6 text-sm text-slate-600">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-primary-500">주요 성과</p>
+              <p className="mt-2 text-base font-semibold text-slate-900">
+                운영 대시보드 UX 개선으로 모니터링 시간 35% 단축, KPI 대응 속도 25% 향상
+              </p>
+            </div>
+            <ul className="grid gap-3">
+              {[
+                "실사용자 데이터 기반의 문제 정의",
+                "리얼타임 그래프/차트 퍼포먼스 최적화",
+                "현장과의 소통을 위한 문서 & 시연 주도"
+              ].map((value) => (
+                <li key={value} className="flex items-start gap-3">
+                  <span className="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary-100 font-semibold text-primary-600">•</span>
+                  <span>{value}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="rounded-2xl border border-white/60 bg-white/80 p-4 text-xs text-slate-500 shadow-inner">
+              <p className="font-semibold text-primary-600">현재 관심 키워드</p>
+              <p className="mt-1">O-RAN 관제, 실시간 분석 UX, 에너지 최적화 서비스, 디자인 시스템 운영</p>
+            </div>
+          </div>
+          <Image
+            src="/images/hero/profile-bubble.svg"
+            alt="색상 원형 배경"
+            width={320}
+            height={320}
+            className="pointer-events-none absolute -bottom-16 -right-10 opacity-70"
+            priority
+          />
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/portfolio/src/components/Navigation.module.scss
+++ b/portfolio/src/components/Navigation.module.scss
@@ -1,0 +1,9 @@
+.progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: linear-gradient(90deg, #7f5af0 0%, #1f7aff 100%);
+  transform-origin: left;
+}

--- a/portfolio/src/components/Navigation.tsx
+++ b/portfolio/src/components/Navigation.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Bars3Icon } from "@heroicons/react/24/outline";
+import { motion, useScroll, useSpring, useTransform, useMotionTemplate } from "framer-motion";
+import styles from "./Navigation.module.scss";
+
+const links = [
+  { href: "#projects", label: "프로젝트" },
+  { href: "#skills", label: "역량" },
+  { href: "#career", label: "경력" },
+  { href: "#contact", label: "연락처" }
+];
+
+export function Navigation() {
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress, { stiffness: 120, damping: 20, restDelta: 0.001 });
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setIsScrolled(window.scrollY > 12);
+    handler();
+    window.addEventListener("scroll", handler);
+    return () => window.removeEventListener("scroll", handler);
+  }, []);
+
+  const backgroundOpacity = useTransform(scrollYProgress, [0, 0.1], [0.2, 0.6]);
+  const backgroundColor = useMotionTemplate`rgba(249, 252, 255, ${backgroundOpacity})`;
+
+  return (
+    <header className="sticky top-0 z-50 relative">
+      <motion.div style={{ scaleX }} className={styles.progress} />
+      <motion.nav className="backdrop-blur-md" style={{ backgroundColor }}>
+        <div
+          className={`flex items-center justify-between gap-6 rounded-full border border-slate-200/70 px-5 py-3 shadow-lg shadow-primary-100/40 transition-all sm:px-8 ${
+            isScrolled ? "mt-4" : "mt-6"
+          }`}
+        >
+          <Link href="#top" className="font-display text-lg font-semibold text-primary-700">
+            Jian Choi
+          </Link>
+          <div className="hidden items-center gap-6 text-sm font-medium text-slate-600 md:flex">
+            {links.map((link) => (
+              <a key={link.href} href={link.href} className="transition-colors hover:text-primary-600">
+                {link.label}
+              </a>
+            ))}
+          </div>
+          <button className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-colors hover:border-primary-200 hover:text-primary-500 md:hidden">
+            <Bars3Icon className="h-5 w-5" />
+          </button>
+        </div>
+      </motion.nav>
+    </header>
+  );
+}

--- a/portfolio/src/components/ProjectCard.module.scss
+++ b/portfolio/src/components/ProjectCard.module.scss
@@ -1,0 +1,23 @@
+.figure {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at top left, rgba(127, 90, 240, 0.15), rgba(31, 122, 255, 0.05));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.default {
+  color: #475569;
+}
+
+.muted {
+  color: #64748b;
+}
+
+.accent {
+  color: #4338ca;
+}

--- a/portfolio/src/components/ProjectCard.tsx
+++ b/portfolio/src/components/ProjectCard.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+import type { Project } from "@/data/projects";
+import styles from "./ProjectCard.module.scss";
+
+type ProjectCardProps = {
+  project: Project;
+  index: number;
+};
+
+export function ProjectCard({ project, index }: ProjectCardProps) {
+  return (
+    <article className="grid gap-8 rounded-3xl border border-slate-200/70 bg-white/90 p-8 shadow-lg shadow-primary-100/40 lg:grid-cols-[1fr_1.1fr]">
+      <div className="space-y-4">
+        <span className="inline-flex items-center gap-2 text-xs font-semibold text-primary-500">
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary-100 font-semibold text-primary-600">
+            {index + 1}
+          </span>
+          {project.period}
+        </span>
+        <h3 className="font-display text-2xl font-bold text-slate-900">{project.title}</h3>
+        <p className="text-sm text-slate-600">{project.subtitle}</p>
+        <div className="flex flex-wrap gap-2 text-[13px] text-primary-600">
+          {project.stacks.map((stack) => (
+            <span key={stack} className="rounded-full border border-primary-200 bg-primary-50 px-3 py-1">
+              {stack}
+            </span>
+          ))}
+        </div>
+        {project.highlight && (
+          <div className="rounded-2xl border border-accent/30 bg-accent/10 p-4 text-sm text-accent">
+            {project.highlight}
+          </div>
+        )}
+        <div className="grid gap-3 text-sm text-slate-600">
+          <SectionList title="주요 기여" items={project.roles} />
+          <SectionList title="문제 상황" items={project.problems} variant="muted" />
+          <SectionList title="해결 접근" items={project.solutions} />
+          <SectionList title="성과" items={project.achievements} variant="accent" />
+        </div>
+      </div>
+      <div className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {project.images.map((image) => (
+            <figure key={image.src} className={styles.figure}>
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={560}
+                height={320}
+                className="h-full w-full rounded-2xl object-cover"
+              />
+              <figcaption className="text-xs text-slate-500">{image.title}</figcaption>
+            </figure>
+          ))}
+        </div>
+        <p className="text-xs text-slate-500">{project.organization}</p>
+      </div>
+    </article>
+  );
+}
+
+type SectionListProps = {
+  title: string;
+  items: string[];
+  variant?: "default" | "muted" | "accent";
+};
+
+function SectionList({ title, items, variant = "default" }: SectionListProps) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wider text-primary-500">{title}</p>
+      <ul className={`mt-2 space-y-2 text-sm leading-relaxed ${styles[variant]}`}>
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/portfolio/src/components/ProjectSection.tsx
+++ b/portfolio/src/components/ProjectSection.tsx
@@ -1,0 +1,20 @@
+import { projects } from "@/data/projects";
+import { ProjectCard } from "./ProjectCard";
+import { SectionHeader } from "./SectionHeader";
+
+export function ProjectSection() {
+  return (
+    <section id="projects" className="space-y-8">
+      <SectionHeader
+        eyebrow="업무 프로젝트"
+        title="데이터 기반 대시보드 & 반응형 서비스 경험"
+        description="실제 사용자와 현장의 요구를 반영한 프로젝트를 중심으로 기획부터 UI/UX, 데이터 연동까지 전 과정을 주도한 사례들입니다."
+      />
+      <div className="space-y-8">
+        {projects.map((project, index) => (
+          <ProjectCard key={project.id} project={project} index={index} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/portfolio/src/components/SectionHeader.module.scss
+++ b/portfolio/src/components/SectionHeader.module.scss
@@ -1,0 +1,10 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(164, 202, 255, 0.35), rgba(127, 90, 240, 0.25));
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.15);
+}

--- a/portfolio/src/components/SectionHeader.tsx
+++ b/portfolio/src/components/SectionHeader.tsx
@@ -1,0 +1,17 @@
+import styles from "./SectionHeader.module.scss";
+
+type SectionHeaderProps = {
+  eyebrow: string;
+  title: string;
+  description?: string;
+};
+
+export function SectionHeader({ eyebrow, title, description }: SectionHeaderProps) {
+  return (
+    <div className="space-y-3">
+      <span className={`${styles.badge} text-xs font-semibold uppercase tracking-wider text-primary-600`}>{eyebrow}</span>
+      <h2 className="font-display text-3xl font-bold text-slate-900 sm:text-4xl">{title}</h2>
+      {description && <p className="max-w-3xl text-sm text-slate-600">{description}</p>}
+    </div>
+  );
+}

--- a/portfolio/src/components/SkillSection.tsx
+++ b/portfolio/src/components/SkillSection.tsx
@@ -1,0 +1,55 @@
+import { SectionHeader } from "./SectionHeader";
+
+const skills = [
+  {
+    title: "Frontend Engineering",
+    items: [
+      "Next.js, React, TypeScript 기반의 모듈 설계",
+      "TanStack Query, Zustand, Recoil 상태관리 최적화",
+      "고성능 데이터 테이블 & 차트 컴포넌트 설계"
+    ]
+  },
+  {
+    title: "Design & Communication",
+    items: [
+      "Figma를 활용한 디자인 시스템 & 문서화",
+      "사용자 여정 기반 와이어프레임 및 프로토타이핑",
+      "연구원/운영팀 대상 릴리즈 리뷰 및 교육 세션 진행"
+    ]
+  },
+  {
+    title: "Data Experience",
+    items: [
+      "실시간 로그/시계열 데이터 시각화",
+      "API 신뢰성 확보를 위한 예외 처리 & 모니터링",
+      "데이터 품질 진단을 위한 툴링 제작"
+    ]
+  }
+];
+
+export function SkillSection() {
+  return (
+    <section id="skills" className="space-y-8">
+      <SectionHeader
+        eyebrow="핵심 역량"
+        title="사용자 경험과 데이터 정확도를 동시에 잡는 기술"
+        description="프로덕트 팀과 연구 현장 사이에서 커뮤니케이션을 조율하며, 데이터 기반 기능을 안정적으로 제공하기 위한 역량을 다듬어왔습니다."
+      />
+      <div className="grid gap-6 md:grid-cols-3">
+        {skills.map((skill) => (
+          <div key={skill.title} className="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-lg shadow-primary-100/30">
+            <h3 className="font-display text-lg font-semibold text-primary-700">{skill.title}</h3>
+            <ul className="mt-4 space-y-3 text-sm text-slate-600">
+              {skill.items.map((item) => (
+                <li key={item} className="flex gap-3">
+                  <span className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-primary-300" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/portfolio/src/components/SummarySection.tsx
+++ b/portfolio/src/components/SummarySection.tsx
@@ -1,0 +1,51 @@
+import { SectionHeader } from "./SectionHeader";
+
+const summaries = [
+  {
+    title: "프로젝트 요약",
+    items: [
+      "O-RAN RICS 관제 대시보드 1.0/2.0",
+      "에너지 절감 rApp 시각화 대시보드",
+      "울산 하늘공원 장례식장 반응형 웹"
+    ]
+  },
+  {
+    title: "핵심 역할",
+    items: [
+      "데이터 시각화/UX 리디자인 주도",
+      "Mock API/테스트 환경 구성",
+      "관계자 커뮤니케이션 및 교육"
+    ]
+  },
+  {
+    title: "성과",
+    items: [
+      "모니터링 시간 35% 단축",
+      "오류 대응 속도 25% 향상",
+      "모바일 전환율 33% 증가"
+    ]
+  }
+];
+
+export function SummarySection() {
+  return (
+    <section aria-labelledby="summary" className="rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-lg shadow-primary-100/30">
+      <SectionHeader eyebrow="한눈에 보는 요약" title="프로젝트 맥락과 성과" />
+      <div className="mt-6 grid gap-6 md:grid-cols-3">
+        {summaries.map((summary) => (
+          <div key={summary.title} className="rounded-2xl border border-slate-200/60 bg-gradient-to-br from-white via-white to-primary-50/40 p-6">
+            <h3 className="font-display text-lg font-semibold text-slate-900">{summary.title}</h3>
+            <ul className="mt-4 space-y-2 text-sm text-slate-600">
+              {summary.items.map((item) => (
+                <li key={item} className="flex gap-2">
+                  <span className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-primary-400" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/portfolio/src/data/projects.ts
+++ b/portfolio/src/data/projects.ts
@@ -1,0 +1,161 @@
+export type Project = {
+  id: string;
+  title: string;
+  subtitle: string;
+  period: string;
+  organization: string;
+  stacks: string[];
+  roles: string[];
+  achievements: string[];
+  problems: string[];
+  solutions: string[];
+  images: {
+    title: string;
+    alt: string;
+    src: string;
+  }[];
+  highlight?: string;
+};
+
+export const projects: Project[] = [
+  {
+    id: "oran-dashboard-2",
+    title: "O-RAN RICS 관리 대시보드 2.0",
+    subtitle: "ETRI 내 현장 운영팀이 실시간 모니터링 가능한 통합 대시보드",
+    period: "2024.09.12 - 2024.12.31 (4개월)",
+    organization: "한국전자통신연구원(ETRI) 지능형 스웜랩 연구실",
+    stacks: [
+      "React",
+      "TypeScript",
+      "SCSS",
+      "Axios",
+      "TanStack Query",
+      "Zustand",
+      "Figma"
+    ],
+    roles: [
+      "사용자 친화형 관제 UI/UX 개발",
+      "실시간 라인차트/지표 대시보드 구현",
+      "데이터 품질 검증 로직 & 예외 처리 설계",
+      "큐레이션형 UX 마이크로 인터랙션 설계"
+    ],
+    achievements: [
+      "실서비스 적용과 동시에 현장 운영팀의 모니터링 시간을 35% 단축",
+      "데이터 품질 이슈를 자동 감지하여 운영팀 알림 기능 제공",
+      "하나의 대시보드에서 다중 관제 시나리오를 지원"
+    ],
+    problems: [
+      "이전 버전의 낮은 시인성과 이해하기 어려운 데이터 구조",
+      "다양한 사용자 유형을 위한 가변형 레이아웃 요구",
+      "대규모 시계열 데이터 렌더링에 따른 성능 저하"
+    ],
+    solutions: [
+      "카드 기반 레이아웃과 컬러 시스템 재정의로 UI 가독성 향상",
+      "Flex 기반 반응형 템플릿과 사용자별 위젯 프리셋 제공",
+      "가상 스크롤과 청크 로딩으로 렌더링 성능 40% 개선"
+    ],
+    images: [
+      { title: "Dashboard", alt: "대시보드 전반", src: "/images/projects/oran-dashboard-2/dashboard.svg" },
+      { title: "Diagnostic Monitor", alt: "진단 모니터", src: "/images/projects/oran-dashboard-2/diagnostic.svg" },
+      { title: "Performance", alt: "성능 지표", src: "/images/projects/oran-dashboard-2/performance.svg" }
+    ],
+    highlight: "실사용자 피드백 기반으로 하루 3회 모니터링 플로우를 최적화"
+  },
+  {
+    id: "oran-dashboard-1",
+    title: "O-RAN RICS 관리 대시보드 1.0",
+    subtitle: "O-RAN RIC 구성 요소를 차트/로그/형상으로 실시간 모니터링",
+    period: "2024.07.01 - 2024.08.31 (2개월)",
+    organization: "한국전자통신연구원(ETRI) 지능형 스웜랩 연구실",
+    stacks: ["React", "TypeScript", "SCSS", "TanStack Query", "Zustand", "Figma"],
+    roles: [
+      "TanStack-query 기반 리얼타임 데이터 동기화",
+      "모듈화된 API 클라이언트와 전역 스토어 설계",
+      "차트/테이블/타임라인 패턴 라이브러리 개발"
+    ],
+    achievements: [
+      "Mock API를 활용한 선행 개발로 실데이터 연동 기간 30% 단축",
+      "데이터 품질/베이스라인 검증 자동화",
+      "오류 대응 시간 25% 단축"
+    ],
+    problems: [
+      "이기종 장비에서 오는 API 지연",
+      "운영자가 필요한 지표를 즉시 찾기 어려움",
+      "화면 밀집도와 UX 혼잡도 증가"
+    ],
+    solutions: [
+      "요청 큐 기반 API 재시도와 지연 지표 표시",
+      "지표 검색/태깅 및 즐겨찾기 기능 제공",
+      "UI 정보구조 리디자인 및 스켈레톤 로딩 적용"
+    ],
+    images: [
+      { title: "Dashboard", alt: "대시보드", src: "/images/projects/oran-dashboard-1/dashboard.svg" },
+      { title: "Non-RT RIC", alt: "Non-RT RIC 화면", src: "/images/projects/oran-dashboard-1/non-rt.svg" },
+      { title: "Near-RT RIC", alt: "Near-RT RIC 화면", src: "/images/projects/oran-dashboard-1/near-rt.svg" }
+    ]
+  },
+  {
+    id: "energy-rapp",
+    title: "오픈랜 시스템에서 에너지 절감 rApp 시각화 대시보드",
+    subtitle: "에너지 절감을 위한 rApp KPI 모니터링",
+    period: "2024.01.01 - 2024.08.31 (8개월)",
+    organization: "한국전자통신연구원(ETRI) 지능형 스웜랩 연구실",
+    stacks: ["React", "TypeScript", "Recharts", "React-Query", "Styled-components"],
+    roles: [
+      "실시간 KPI 카드/그래프 UI 개발",
+      "에너지 절감 시나리오 기반 UX 설계",
+      "다중 레이아웃 반응형 차트 구현"
+    ],
+    achievements: [
+      "에너지 절감 KPI 시뮬레이션 시나리오 시각화",
+      "시계열 데이터 가시화 정확도 향상",
+      "내부 PoC를 통해 실제 장비 연동까지 확장"
+    ],
+    problems: [
+      "실시간 데이터 처리 중 끊김 현상",
+      "복잡한 차트 구성과 반응형 이슈",
+      "시뮬레이션 결과의 비교 가시성 부족"
+    ],
+    solutions: [
+      "웹소켓 구독과 데이터 스로틀링으로 안정화",
+      "반응형 차트 템플릿 및 범례 가이드 제공",
+      "시나리오별 비교 카드 및 강조 색 체계 도입"
+    ],
+    images: [
+      { title: "Energy Monitor", alt: "에너지 모니터", src: "/images/projects/energy-rapp/monitor.svg" },
+      { title: "Site Overview", alt: "사이트 전체", src: "/images/projects/energy-rapp/overview.svg" }
+    ]
+  },
+  {
+    id: "ulsan-memorial",
+    title: "울산 하늘공원 장례식장 반응형 홈페이지 외주 개발",
+    subtitle: "장례식장 예약/안내 반응형 웹",
+    period: "2024.07.30 - 2025.01.07 (5개월)",
+    organization: "울산 하늘공원 장례식장",
+    stacks: ["TypeScript", "React", "Recoil", "SCSS", "Styled-components", "Figma"],
+    roles: [
+      "4단계 캐러셀 기반 시설 소개 페이지 개발",
+      "장례 일정/부고 알림 기능 개발",
+      "모바일/데스크탑 전용 UI 가이드 제작"
+    ],
+    achievements: [
+      "시설 예약 문의 전환율 33% 증가",
+      "모바일 방문자의 페이지 이탈률 28% 감소",
+      "유가족 케어 기능 통한 상담 만족도 향상"
+    ],
+    problems: [
+      "장례 절차 정보 구조의 복잡성",
+      "모바일 사용성 문제",
+      "운영팀의 콘텐츠 업데이트 요구"
+    ],
+    solutions: [
+      "사용자 여정 기반 네비게이션 재구성",
+      "모바일 우선 반응형 그리드 설계",
+      "CMS 연동 가능한 모듈식 컴포넌트 구축"
+    ],
+    images: [
+      { title: "Intro Page", alt: "인트로 페이지", src: "/images/projects/ulsan-memorial/intro.svg" },
+      { title: "Facility", alt: "시설 안내", src: "/images/projects/ulsan-memorial/facility.svg" }
+    ]
+  }
+];

--- a/portfolio/tailwind.config.ts
+++ b/portfolio/tailwind.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+import typography from "@tailwindcss/typography";
+
+const config: Config = {
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/content/**/*.{ts,tsx,md,mdx}",
+    "./src/styles/**/*.{ts,tsx,scss}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Pretendard Variable", ...defaultTheme.fontFamily.sans],
+        display: ["Sora", ...defaultTheme.fontFamily.sans]
+      },
+      colors: {
+        primary: {
+          50: "#eef6ff",
+          100: "#d2e5ff",
+          200: "#a5caff",
+          300: "#78afff",
+          400: "#4b94ff",
+          500: "#1f7aff",
+          600: "#0a5fd6",
+          700: "#0647a3",
+          800: "#032f70",
+          900: "#01173d"
+        },
+        accent: "#7f5af0"
+      }
+    }
+  },
+  plugins: [typography]
+};
+
+export default config;

--- a/portfolio/tsconfig.json
+++ b/portfolio/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 + TypeScript app configured with Tailwind CSS and SCSS modules for the new portfolio frontend
- implement hero, project, skills, and career sections backed by typed project data and reusable UI components
- add illustrative SVG assets, typography, and documentation for running the responsive portfolio across devices

## Testing
- not run (network access to install npm dependencies is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe054319948327abd0db5d6013f716